### PR TITLE
Make extension compatible with Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,1 +1,0 @@
-// background.js (optional for further features)

--- a/content.js
+++ b/content.js
@@ -1,1 +1,0 @@
-// content.js - You can leave this empty as we're injecting the shuffle logic dynamically

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,7 @@
   "name": "Image Shuffler",
   "version": "1.0",
   "description": "Shuffle image paths on the current website",
-  "permissions": ["activeTab", "scripting", "tabs"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": ["activeTab", "scripting"],
   "action": {
     "default_popup": "popup.html"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -6,11 +6,5 @@
   "permissions": ["activeTab", "scripting"],
   "action": {
     "default_popup": "popup.html"
-  },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content.js"]
-    }
-  ]
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,10 +3,8 @@
   "name": "Image Shuffler",
   "version": "1.0",
   "description": "Shuffle image paths on the current website",
-  "permissions": ["activeTab", "scripting"],
-  "background": {
-    "service_worker": "background.js"
-  },
+  "permissions": ["activeTab", "scripting", "tabs"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "popup.html"
   },

--- a/popup.js
+++ b/popup.js
@@ -1,13 +1,19 @@
-document.getElementById('shuffle-btn').addEventListener('click', () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        chrome.scripting.executeScript({
-            target: { tabId: tabs[0].id },
-            function: shuffleImages
+document.addEventListener('DOMContentLoaded', function () {
+    const shuffleBtn = document.getElementById('shuffle-btn');
+
+    shuffleBtn.addEventListener('click', () => {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            chrome.scripting.executeScript({
+                target: { tabId: tabs[0].id },
+                func: shuffleImages
+            });
         });
     });
 });
 
 function shuffleImages() {
+    console.info("shuffle images executed");
+    
     // Remove all source elements from the DOM
     const sources = document.querySelectorAll('source');
     sources.forEach(source => source.remove());


### PR DESCRIPTION
At least not as a service worker, and providing different manifest files for a feature we don't even use sounds not very useful: https://github.com/mozilla/web-ext/issues/2532

Also adjusted a "typo". https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript -> "function" is actually wrong and should be in Chrome too, I don't know why it worked there, but `func` let's it work flawlessly, in any case.

![Bildschirmfoto vom 2024-10-16 22-36-04](https://github.com/user-attachments/assets/7c0c87f7-4c0b-40f9-9fe2-044017740640)
